### PR TITLE
Add a storefront denylist.

### DIFF
--- a/crates/core/migrations/2021-12-21-201423_create_store_denylist/down.sql
+++ b/crates/core/migrations/2021-12-21-201423_create_store_denylist/down.sql
@@ -1,0 +1,1 @@
+drop table store_denylist;

--- a/crates/core/migrations/2021-12-21-201423_create_store_denylist/up.sql
+++ b/crates/core/migrations/2021-12-21-201423_create_store_denylist/up.sql
@@ -1,0 +1,3 @@
+create table store_denylist (
+  owner_address varchar(48) primary key not null
+);

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -10,7 +10,7 @@ pub mod tables {
 
     pub use super::schema::{
         editions, listing_metadatas, listings, master_editions, metadata_creators, metadatas,
-        storefronts,
+        store_denylist, storefronts,
     };
 }
 

--- a/crates/core/src/db/queries/mod.rs
+++ b/crates/core/src/db/queries/mod.rs
@@ -1,3 +1,4 @@
 //! Reusable query operations for common or complicated queries.
 
 pub mod listings_triple_join;
+pub mod store_denylist;

--- a/crates/core/src/db/queries/store_denylist.rs
+++ b/crates/core/src/db/queries/store_denylist.rs
@@ -15,6 +15,8 @@ use crate::db::tables::{store_denylist, storefronts};
 // Would you believe it took me 2 hours to debug type errors for this module?
 
 type EqOwnerAddr<A> = Eq<store_denylist::owner_address, AsExprOf<A, VarChar>>;
+
+/// The resulting type of the [`owner_address_ok`] function
 pub type OwnerAddressOk<A> =
     Not<Exists<Filter<SelectStatement<store_denylist::table>, EqOwnerAddr<A>>>>;
 
@@ -32,6 +34,7 @@ where
 }
 
 /// Query all storefronts whose owner address is not in the denylist
+#[must_use]
 pub fn get_storefronts() -> Filter<storefronts::table, OwnerAddressOk<storefronts::owner_address>> {
     FilterDsl::filter(
         storefronts::table,

--- a/crates/core/src/db/queries/store_denylist.rs
+++ b/crates/core/src/db/queries/store_denylist.rs
@@ -1,0 +1,40 @@
+//! Query utilities for using the store denylist table.
+
+use diesel::{
+    dsl::{exists, not, AsExprOf, Filter},
+    expression::{exists::Exists, operators::Eq, AsExpression},
+    helper_types::not as Not,
+    prelude::*,
+    query_builder::{SelectQuery, SelectStatement},
+    query_dsl::methods::FilterDsl,
+    sql_types::VarChar,
+};
+
+use crate::db::tables::{store_denylist, storefronts};
+
+// Would you believe it took me 2 hours to debug type errors for this module?
+
+type EqOwnerAddr<A> = Eq<store_denylist::owner_address, AsExprOf<A, VarChar>>;
+pub type OwnerAddressOk<A> =
+    Not<Exists<Filter<SelectStatement<store_denylist::table>, EqOwnerAddr<A>>>>;
+
+/// Generate an SQL boolean expression that is true if `address` does not appear
+/// in the `owner_address` column of the `store_denylist` table.
+pub fn owner_address_ok<A: AsExpression<VarChar>>(address: A) -> OwnerAddressOk<A>
+where
+    SelectStatement<store_denylist::table>: FilterDsl<EqOwnerAddr<A>>,
+    Filter<store_denylist::table, EqOwnerAddr<A>>: SelectQuery,
+{
+    not(exists(FilterDsl::filter(
+        store_denylist::table,
+        store_denylist::owner_address.eq(address),
+    )))
+}
+
+/// Query all storefronts whose owner address is not in the denylist
+pub fn get_storefronts() -> Filter<storefronts::table, OwnerAddressOk<storefronts::owner_address>> {
+    FilterDsl::filter(
+        storefronts::table,
+        owner_address_ok(storefronts::owner_address),
+    )
+}

--- a/crates/core/src/db/schema.rs
+++ b/crates/core/src/db/schema.rs
@@ -67,6 +67,12 @@ table! {
 }
 
 table! {
+    store_denylist (owner_address) {
+        owner_address -> Varchar,
+    }
+}
+
+table! {
     storefronts (owner_address) {
         owner_address -> Varchar,
         subdomain -> Text,
@@ -90,5 +96,6 @@ allow_tables_to_appear_in_same_query!(
     master_editions,
     metadata_creators,
     metadatas,
+    store_denylist,
     storefronts,
 );

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -28,6 +28,7 @@ pub mod prelude {
 
     pub use chrono::{self, prelude::*};
     pub use diesel::{
+        dsl::{exists, not},
         expression_methods::*,
         query_dsl::{BelongingToDsl, GroupByDsl, JoinOnDsl, QueryDsl, RunQueryDsl, SaveChangesDsl},
     };

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -1,6 +1,6 @@
 use indexer_core::db::{
     models::{Metadata, Storefront},
-    queries::listings_triple_join,
+    queries::{listings_triple_join, store_denylist},
     tables::{listing_metadatas, metadatas, storefronts},
     Pool, PooledConnection,
 };
@@ -61,7 +61,7 @@ impl Rpc for Server {
 
     fn get_storefronts(&self) -> Result<Vec<RpcStorefront>> {
         let db = self.db()?;
-        let rows: Vec<Storefront> = storefronts::table
+        let rows: Vec<Storefront> = store_denylist::get_storefronts()
             .order_by(storefronts::owner_address)
             .load(&db)
             .map_err(internal_error("Failed to load storefronts"))?;
@@ -90,7 +90,7 @@ impl Rpc for Server {
 
     fn get_store_count(&self) -> Result<i64> {
         let db = self.db()?;
-        storefronts::table
+        store_denylist::get_storefronts()
             .count()
             .get_result(&db)
             .map_err(internal_error("Failed to get store count"))


### PR DESCRIPTION
Current implementation tracks owner pubkeys and remove any associated storefronts from RPC queries.

We should be certain that this is watertight before merging.