### PR TITLE
Index token accounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,6 +2359,7 @@ dependencies = [
  "solana-client",
  "solana-program",
  "solana-sdk",
+ "spl-token",
  "tokio 1.14.0",
  "topograph",
 ]

--- a/crates/core/migrations/2022-01-18-164927_create_token_accounts_table/down.sql
+++ b/crates/core/migrations/2022-01-18-164927_create_token_accounts_table/down.sql
@@ -1,0 +1,1 @@
+drop table token_accounts;

--- a/crates/core/migrations/2022-01-18-164927_create_token_accounts_table/up.sql
+++ b/crates/core/migrations/2022-01-18-164927_create_token_accounts_table/up.sql
@@ -1,7 +1,7 @@
 create table token_accounts (
-  address varchar(48) primary key not null,
-  mint_address varchar(48) not null,
+  address       varchar(48) primary key not null,
+  mint_address  varchar(48) not null,
   owner_address varchar(48) not null,
-  amount bigint default 0,
-  updated_at timestamp not null
-)
+  amount        bigint      default 0,
+  updated_at    timestamp   not null
+);

--- a/crates/core/migrations/2022-01-18-164927_create_token_accounts_table/up.sql
+++ b/crates/core/migrations/2022-01-18-164927_create_token_accounts_table/up.sql
@@ -3,6 +3,5 @@ create table token_accounts (
   mint_address varchar(48) not null,
   owner_address varchar(48) not null,
   amount bigint default 0,
-  created_at timestamp not null,
-  updated_at timestamp
+  updated_at timestamp not null
 )

--- a/crates/core/migrations/2022-01-18-164927_create_token_accounts_table/up.sql
+++ b/crates/core/migrations/2022-01-18-164927_create_token_accounts_table/up.sql
@@ -1,0 +1,8 @@
+create table token_accounts (
+  address varchar(48) primary key not null,
+  mint_address varchar(48) not null,
+  owner_address varchar(48) not null,
+  amount bigint default 0,
+  created_at timestamp not null,
+  updated_at timestamp
+)

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -10,7 +10,7 @@ pub mod tables {
 
     pub use super::schema::{
         bids, editions, listing_metadatas, listings, master_editions, metadata_creators, metadatas,
-        store_denylist, storefronts,
+        store_denylist, storefronts, token_accounts,
     };
 }
 

--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -9,7 +9,7 @@ use chrono::NaiveDateTime;
 
 use super::schema::{
     bids, editions, listing_metadatas, listings, master_editions, metadata_creators, metadatas,
-    storefronts, token_accounts
+    storefronts, token_accounts,
 };
 
 /// A row in the `bids` table
@@ -136,10 +136,8 @@ pub struct TokenAccount<'a> {
     pub owner_address: Cow<'a, str>,
     /// The amount of the token, often 1
     pub amount: i64,
-    /// created_at
-    pub created_at: NaiveDateTime,
     /// updated_at
-    pub updated_at: Option<NaiveDateTime>,
+    pub updated_at: NaiveDateTime,
 }
 
 /// A row in the `metadatas` table

--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -9,7 +9,7 @@ use chrono::NaiveDateTime;
 
 use super::schema::{
     bids, editions, listing_metadatas, listings, master_editions, metadata_creators, metadatas,
-    storefronts,
+    storefronts, token_accounts
 };
 
 /// A row in the `bids` table
@@ -122,6 +122,24 @@ pub struct MetadataCreator<'a> {
     pub share: i32,
     /// Whether this creator has verified this metadata
     pub verified: bool,
+}
+
+/// A row in the `token_accounts` table
+/// helpful for tracking exchanges of tokens
+#[derive(Debug, Clone, Queryable, Insertable, AsChangeset)]
+pub struct TokenAccount<'a> {
+    /// The address of this account
+    pub address: Cow<'a, str>,
+    /// The mint address of the token
+    pub mint_address: Cow<'a, str>,
+    /// The owner token
+    pub owner_address: Cow<'a, str>,
+    /// The amount of the token, often 1
+    pub amount: i64,
+    /// created_at
+    pub created_at: NaiveDateTime,
+    /// updated_at
+    pub updated_at: Option<NaiveDateTime>,
 }
 
 /// A row in the `metadatas` table

--- a/crates/core/src/db/schema.rs
+++ b/crates/core/src/db/schema.rs
@@ -124,6 +124,20 @@ table! {
     }
 }
 
+table! {
+    use diesel::sql_types::*;
+    use diesel_full_text_search::{TsVector as Tsvector, TsQuery as Tsquery};
+
+    token_accounts (address) {
+        address -> Varchar,
+        mint_address -> Varchar,
+        owner_address -> Varchar,
+        amount -> Nullable<Int8>,
+        created_at -> Timestamp,
+        updated_at -> Nullable<Timestamp>,
+    }
+}
+
 joinable!(bids -> listings (listing_address));
 joinable!(editions -> master_editions (parent_address));
 joinable!(editions -> metadatas (metadata_address));
@@ -143,4 +157,5 @@ allow_tables_to_appear_in_same_query!(
     metadatas,
     store_denylist,
     storefronts,
+    token_accounts,
 );

--- a/crates/core/src/db/schema.rs
+++ b/crates/core/src/db/schema.rs
@@ -133,8 +133,7 @@ table! {
         mint_address -> Varchar,
         owner_address -> Varchar,
         amount -> Nullable<Int8>,
-        created_at -> Timestamp,
-        updated_at -> Nullable<Timestamp>,
+        updated_at -> Timestamp,
     }
 }
 

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -30,6 +30,7 @@ metaplex-token-vault = "0.0.1"
 solana-client = "1.8.3"
 solana-program = "1.8.3"
 solana-sdk = "1.8.3"
+spl-token = "3.2.0"
 
 [dependencies.indexer-core]
 package = "metaplex-indexer-core"

--- a/crates/indexer/src/bits/mod.rs
+++ b/crates/indexer/src/bits/mod.rs
@@ -5,3 +5,4 @@ pub mod edition;
 pub mod get_storefronts;
 pub mod metadata;
 pub mod store_owner;
+pub mod token_account;

--- a/crates/indexer/src/bits/token_account.rs
+++ b/crates/indexer/src/bits/token_account.rs
@@ -1,0 +1,30 @@
+use std::borrow::Borrow;
+
+use chrono::{offset::Local, Duration, NaiveDateTime};
+use indexer_core::{
+    db::{
+        insert_into,
+        models::{Bid, Listing},
+        select,
+        tables::{bids, listings},
+        Connection,
+    },
+    prelude::*,
+    pubkeys::find_auction_data_extended,
+};
+use metaplex_auction::processor::{
+    AuctionData, AuctionDataExtended, BidState, BidderMetadata, PriceFloor,
+};
+
+use super::bidder_metadata::BidMap;
+use crate::{
+    bits::bidder_metadata::BidList, prelude::*, util, Client, RcAuctionKeys, ThreadPoolHandle,
+};
+
+pub fn process(
+    client: &Client,
+    token_account: Pubkey,
+) -> Result<()> {
+  
+  Ok(())
+}

--- a/crates/indexer/src/bits/token_account.rs
+++ b/crates/indexer/src/bits/token_account.rs
@@ -26,7 +26,10 @@ pub fn process(client: &Client, pubkey: Pubkey, token_account: TokenAccount) -> 
     }
 
     let pubkey = pubkey.to_string();
-    let amount = token_account.amount as i64;
+    let amount: i64 = token_account
+        .amount
+        .try_into()
+        .context("Token amount was too big to store")?;
     let owner = token_account.owner.to_string();
     let now = Local::now().naive_utc();
 

--- a/crates/indexer/src/bits/token_account.rs
+++ b/crates/indexer/src/bits/token_account.rs
@@ -14,10 +14,7 @@ use crate::{prelude::*, Client};
 
 pub fn process(client: &Client, pubkey: Pubkey, token_account: TokenAccount) -> Result<()> {
     let mint = token_account.mint.to_string();
-    let owner = token_account.owner.to_string();
-    let pubkey = pubkey.to_string();
     let db = client.db()?;
-    let now = Local::now().naive_utc();
 
     if !select(exists(
         metadatas::table.filter(metadatas::mint_address.eq(&mint)),

--- a/crates/indexer/src/bits/token_account.rs
+++ b/crates/indexer/src/bits/token_account.rs
@@ -25,7 +25,10 @@ pub fn process(client: &Client, pubkey: Pubkey, token_account: TokenAccount) -> 
         return Ok(());
     }
 
+    let pubkey = pubkey.to_string();
     let amount = token_account.amount as i64;
+    let owner = token_account.owner.to_string();
+    let now = Local::now().naive_utc();
 
     let values = TokenAccountModel {
         address: Borrowed(&pubkey),

--- a/crates/indexer/src/entry.rs
+++ b/crates/indexer/src/entry.rs
@@ -6,7 +6,7 @@ use topograph::{graph, graph::AdoptableDependents, threaded};
 
 use crate::{
     bits::{
-        auction, auction_cache, bidder_metadata, edition, get_storefronts, metadata, store_owner,
+        auction, auction_cache, bidder_metadata, edition, get_storefronts, metadata, store_owner, token_account
     },
     client::Client,
     prelude::*,
@@ -84,6 +84,8 @@ pub enum Job {
     Auction(RcAuctionKeys),
     /// Attempt to store bids for an auction without indexing the auction
     SoloBidsForAuction(Pubkey, bidder_metadata::BidList),
+    /// Index token accounts so we can know who holds what NFTs  
+    TokenAccount(Pubkey),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -157,6 +159,7 @@ fn create_pool(
                 Job::SoloBidsForAuction(key, ref mut bids) => {
                     auction::process_solo_bids(&client, key, mem::take(bids), handle)
                 },
+                Job::TokenAccount(ref pubkey) => token_account::process(&client, pubkey),
             };
 
             res.map_err(|e| error!("Job {:?} failed: {:?}", job, e))


### PR DESCRIPTION
addresses #46 

By indexing token accounts we know who holds which mints and how many. We are currently limiting this work to token accounts where we know the mint is a currently indexed NFT. We will likely have to return to this later. There could be a race condition where an NFT is created and we miss its token account. Will address in future PRs.