### PR TITLE
add ttl to queue

### DIFF
--- a/crates/rabbitmq/src/accountsdb.rs
+++ b/crates/rabbitmq/src/accountsdb.rs
@@ -8,7 +8,7 @@ use lapin::{
         BasicConsumeOptions, BasicPublishOptions, ExchangeDeclareOptions, QueueBindOptions,
         QueueDeclareOptions,
     },
-    types::FieldTable,
+    types::{AMQPValue, FieldTable},
     BasicProperties, Channel, ExchangeKind,
 };
 use serde::{Deserialize, Serialize};
@@ -102,10 +102,13 @@ impl crate::QueueType<Message> for QueueType {
         )
         .await?;
 
+        let mut queue_options = FieldTable::default();
+        queue_options.insert("x-message-ttl".into(), AMQPValue::LongUInt(60000)); // ten minutes
+
         chan.queue_declare(
             self.queue().as_ref(),
             QueueDeclareOptions::default(),
-            FieldTable::default(),
+            queue_options,
         )
         .await?;
 


### PR DESCRIPTION
Add global 10 minute ttl to our main queue. If we are 10 minutes behind , we likely have a big problem. In the event of a consumer outage, let the message expire. 