### PR TITLE
remove foreign keys for a flat approach to indexing

### DIFF
--- a/crates/core/migrations/2022-01-21-160714_drop_foreign_keys/down.sql
+++ b/crates/core/migrations/2022-01-21-160714_drop_foreign_keys/down.sql
@@ -5,3 +5,4 @@ alter table editions add foreign key (metadata_address) references master_editio
 alter table editions add foreign key (parent_address) references master_editions (address);
 alter table bids add foreign key (listing_address) references listings (address);
 alter table listings add foreign key (store_owner) references storefronts (owner_address);
+alter table master_editions add foreign key (metadata_address) references metadatas (address);

--- a/crates/core/migrations/2022-01-21-160714_drop_foreign_keys/down.sql
+++ b/crates/core/migrations/2022-01-21-160714_drop_foreign_keys/down.sql
@@ -1,0 +1,7 @@
+alter table metadata_creators add foreign key (metadata_address) references metadatas (address);
+alter table listing_metadatas add  foreign key (listing_address) references listings (address);
+alter table listing_metadatas add foreign key (metadata_address) references metadatas (address);
+alter table editions add foreign key (metadata_address) references master_editions (address);
+alter table editions add foreign key (parent_address) references master_editions (address);
+alter table bids add foreign key (listing_address) references listings (address);
+alter table listings add foreign key (store_owner) references storefronts (owner_address);

--- a/crates/core/migrations/2022-01-21-160714_drop_foreign_keys/up.sql
+++ b/crates/core/migrations/2022-01-21-160714_drop_foreign_keys/up.sql
@@ -1,0 +1,7 @@
+alter table metadata_creators drop constraint metadata_creators_metadata_address_fkey;
+alter table listing_metadatas drop constraint listing_metadatas_listing_address_fkey;
+alter table listing_metadatas drop constraint listing_metadatas_metadata_address_fkey;
+alter table editions drop constraint editions_metadata_address_fkey;
+alter table editions drop constraint editions_parent_address_fkey;
+alter table bids drop constraint bids_listing_address_fkey;
+alter table listings drop constraint listings_store_owner_fkey;

--- a/crates/core/migrations/2022-01-21-160714_drop_foreign_keys/up.sql
+++ b/crates/core/migrations/2022-01-21-160714_drop_foreign_keys/up.sql
@@ -5,3 +5,4 @@ alter table editions drop constraint editions_metadata_address_fkey;
 alter table editions drop constraint editions_parent_address_fkey;
 alter table bids drop constraint bids_listing_address_fkey;
 alter table listings drop constraint listings_store_owner_fkey;
+alter table master_editions drop constraint master_editions_metadata_address_fkey;

--- a/crates/core/src/db/queries/listings_triple_join.rs
+++ b/crates/core/src/db/queries/listings_triple_join.rs
@@ -7,7 +7,7 @@ use anyhow::Context;
 use chrono::{Duration, NaiveDateTime};
 use diesel::{
     dsl::not,
-    expression::{nullable::Nullable, operators::Eq as SqlEq},
+    expression::operators::Eq as SqlEq,
     helper_types::{not as Not, And, Eq, Gt, IsNotNull, IsNull, Lt, Or},
     prelude::*,
     query_builder::SelectStatement,
@@ -124,28 +124,31 @@ pub type TripleJoin = SelectStatement<
                     SelectStatement<
                         JoinOn<
                             Join<listing_metadatas::table, metadatas::table, Inner>,
-                            SqlEq<
-                                Nullable<listing_metadatas::metadata_address>,
-                                Nullable<metadatas::address>,
-                            >,
+                            SqlEq<listing_metadatas::metadata_address, metadatas::address>,
                         >,
                     >,
                     Inner,
                 >,
-                SqlEq<Nullable<listing_metadatas::listing_address>, Nullable<listings::address>>,
+                SqlEq<listing_metadatas::listing_address, listings::address>,
             >,
             storefronts::table,
             Inner,
         >,
-        SqlEq<Nullable<listings::store_owner>, Nullable<storefronts::owner_address>>,
+        SqlEq<storefronts::owner_address, listings::store_owner>,
     >,
 >;
 
 /// Join the four input tables
 pub fn join() -> TripleJoin {
     listings::table
-        .inner_join(listing_metadatas::table.inner_join(metadatas::table))
-        .inner_join(storefronts::table)
+        .inner_join(
+            listing_metadatas::table
+                .inner_join(
+                    metadatas::table.on(listing_metadatas::metadata_address.eq(metadatas::address)),
+                )
+                .on(listing_metadatas::listing_address.eq(listings::address)),
+        )
+        .inner_join(storefronts::table.on(storefronts::owner_address.eq(listings::store_owner)))
 }
 
 /// The resulting type of the required WHERE clause

--- a/crates/core/src/db/queries/metadata_edition.rs
+++ b/crates/core/src/db/queries/metadata_edition.rs
@@ -50,8 +50,10 @@ pub fn load<'a>(
 
     let metas = metadatas::table
         .filter(metadatas::address.eq(metadata_address))
-        .left_join(editions::table)
-        .left_join(master_editions::table)
+        .left_join(editions::table.on(editions::metadata_address.eq(metadata_address)))
+        .left_join(
+            master_editions::table.on(master_editions::metadata_address.eq(metadata_address)),
+        )
         .limit(1)
         .select((
             editions::address.nullable(),

--- a/crates/core/src/db/schema.rs
+++ b/crates/core/src/db/schema.rs
@@ -137,8 +137,6 @@ table! {
     }
 }
 
-joinable!(master_editions -> metadatas (metadata_address));
-
 allow_tables_to_appear_in_same_query!(
     bids,
     editions,

--- a/crates/core/src/db/schema.rs
+++ b/crates/core/src/db/schema.rs
@@ -137,14 +137,7 @@ table! {
     }
 }
 
-joinable!(bids -> listings (listing_address));
-joinable!(editions -> master_editions (parent_address));
-joinable!(editions -> metadatas (metadata_address));
-joinable!(listing_metadatas -> listings (listing_address));
-joinable!(listing_metadatas -> metadatas (metadata_address));
-joinable!(listings -> storefronts (store_owner));
 joinable!(master_editions -> metadatas (metadata_address));
-joinable!(metadata_creators -> metadatas (metadata_address));
 
 allow_tables_to_appear_in_same_query!(
     bids,

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -121,7 +121,9 @@ impl Rpc for Server {
     fn get_listing_metadatas(&self, listing_address: String) -> Result<Vec<ListingItem>> {
         let db = self.db()?;
         let rows: Vec<models::Metadata> = listing_metadatas::table
-            .inner_join(metadatas::table)
+            .inner_join(
+                metadatas::table.on(listing_metadatas::metadata_address.eq(metadatas::address)),
+            )
             .filter(listing_metadatas::listing_address.eq(listing_address))
             .select((
                 metadatas::address,


### PR DESCRIPTION
Remove foreign keys, add explicit joins, because diesel requires them now. 