### PR TITLE
Building on AccountsDB & the adventures of Indexer 2: electric boogaloo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2875,6 +2875,7 @@ dependencies = [
  "metaplex",
  "metaplex-auction",
  "metaplex-indexer-core",
+ "metaplex-indexer-rabbitmq",
  "metaplex-token-metadata",
  "metaplex-token-vault",
  "parking_lot",
@@ -2956,6 +2957,7 @@ dependencies = [
  "lapin",
  "rmp-serde",
  "serde",
+ "solana-sdk",
  "strum",
  "thiserror",
 ]
@@ -2976,6 +2978,7 @@ dependencies = [
  "solana-accountsdb-plugin-interface",
  "solana-logger",
  "solana-program",
+ "solana-sdk",
 ]
 
 [[package]]

--- a/crates/accountsdb-rabbitmq/Cargo.toml
+++ b/crates/accountsdb-rabbitmq/Cargo.toml
@@ -29,6 +29,7 @@ smol = "1.2.5"
 solana-accountsdb-plugin-interface = "1.9.4"
 solana-logger = "1.9.4"
 solana-program = "1.9.4"
+solana-sdk = "1.9.4"
 
 [dependencies.indexer-rabbitmq]
 package = "metaplex-indexer-rabbitmq"

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -38,3 +38,11 @@ package = "metaplex-indexer-core"
 version = "=0.1.0"
 path = "../core"
 
+
+[dependencies.indexer-rabbitmq]
+package = "metaplex-indexer-rabbitmq"
+version = "=0.1.0"
+path = "../rabbitmq"
+features = ["accountsdb"]
+
+

--- a/crates/rabbitmq/Cargo.toml
+++ b/crates/rabbitmq/Cargo.toml
@@ -27,3 +27,4 @@ rmp-serde = "1.0.0-beta.2"
 serde = { version = "1.0.133", features = ["derive"] }
 strum = { version = "0.23.0", features = ["derive"], optional = true }
 thiserror = "1.0.30"
+solana-sdk = "1.9.4"

--- a/crates/rabbitmq/src/accountsdb.rs
+++ b/crates/rabbitmq/src/accountsdb.rs
@@ -12,11 +12,9 @@ use lapin::{
     BasicProperties, Channel, ExchangeKind,
 };
 use serde::{Deserialize, Serialize};
+use solana_sdk::pubkey::Pubkey;
 
 use crate::Result;
-
-/// A 256-bit Solana public key
-pub type Pubkey = [u8; 32];
 
 /// A message transmitted by an `accountsdb` plugin
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
Goals of this refactor:
Rely heavily on accounts DB and limit our RPC/network calls wherever possible.
Index all of the accounts we need for indexer v1 (working list)

- [ ] metadata
- [ ] auctions
- [ ] vault
- [ ] bids
- [ ] editions?

addresses #60 