### PR TITLE
More NFT Fields Through GraphQL

### DIFF
--- a/crates/core/src/db/models.rs
+++ b/crates/core/src/db/models.rs
@@ -194,12 +194,24 @@ pub struct Nft {
     // Table metadata
     /// The address of this account
     pub address: String,
+
     /// The name of this item
     pub name: String,
+
+    /// The royalty percentage of the creator, in basis points (0.01%, values
+    /// range from 0-10,000)
+    pub seller_fee_basis_points: i32,
+
+    /// The token address for this item
+    pub mint_address: String,
+
+    /// True if this item is in the secondary market.  Immutable once set.
+    pub primary_sale_happened: bool,
 
     // Table metadata_json
     /// Metadata description
     pub description: Option<String>,
+
     /// Metadata Image url
     pub image: Option<String>,
 }

--- a/crates/graphql/src/schema.rs
+++ b/crates/graphql/src/schema.rs
@@ -434,6 +434,9 @@ impl Wallet {
 struct Nft {
     address: String,
     name: String,
+    seller_fee_basis_points: i32,
+    mint_address: String,
+    primary_sale_happened: bool,
     description: String,
     image: String,
 }
@@ -446,6 +449,18 @@ impl Nft {
 
     pub fn name(&self) -> String {
         self.name.clone()
+    }
+
+    pub fn seller_fee_basis_points(&self) -> i32 {
+        self.seller_fee_basis_points
+    }
+
+    pub fn mint_address(&self) -> String {
+        self.mint_address.clone()
+    }
+
+    pub fn primary_sale_happened(&self) -> bool {
+        self.primary_sale_happened
     }
 
     pub fn description(&self) -> String {
@@ -470,6 +485,9 @@ impl From<models::Nft> for Nft {
         models::Nft {
             address,
             name,
+            seller_fee_basis_points,
+            mint_address,
+            primary_sale_happened,
             description,
             image,
         }: models::Nft,
@@ -477,6 +495,9 @@ impl From<models::Nft> for Nft {
         Self {
             address,
             name,
+            seller_fee_basis_points,
+            mint_address,
+            primary_sale_happened,
             description: description.unwrap_or_else(String::new),
             image: image.unwrap_or_else(String::new),
         }
@@ -682,6 +703,9 @@ impl BatchFn<String, Vec<Nft>> for ListingNftsBatcher {
                 (
                     metadatas::address,
                     metadatas::name,
+                    metadatas::seller_fee_basis_points,
+                    metadatas::mint_address,
+                    metadatas::primary_sale_happened,
                     metadata_jsons::description,
                     metadata_jsons::image,
                 ),
@@ -866,6 +890,9 @@ impl QueryRoot {
             .select((
                 metadatas::address,
                 metadatas::name,
+                metadatas::seller_fee_basis_points,
+                metadatas::mint_address,
+                metadatas::primary_sale_happened,
                 metadata_jsons::description,
                 metadata_jsons::image,
             ))
@@ -898,6 +925,9 @@ impl QueryRoot {
             .select((
                 metadatas::address,
                 metadatas::name,
+                metadatas::seller_fee_basis_points,
+                metadatas::mint_address,
+                metadatas::primary_sale_happened,
                 metadata_jsons::description,
                 metadata_jsons::image,
             ))


### PR DESCRIPTION
### Changes
- Query mint_address, seller fee basis points, and primary sale happened through graphQL API.